### PR TITLE
ET-61 feat: updated activity function

### DIFF
--- a/app/Actions/Payment/PaidActivitiesAction.php
+++ b/app/Actions/Payment/PaidActivitiesAction.php
@@ -25,6 +25,7 @@ class PaidActivitiesAction
             $feeHours = $data->fee_hours;
             $cutoffStatus = $data->cutoff_status;
             $cutoffDate = Carbon::parse($data->cutoff_history->created_at)->format('d F Y H:i');
+            $students = implode(", ", $data->timesheet->ref_program->pluck('student_name')->toArray());
 
             return [
                 'id' => $activityId,
@@ -35,6 +36,7 @@ class PaidActivitiesAction
                     'type' => $package->type_of,
                     'category' => $package->category,
                 ],
+                'students' => $students,
                 'mentor_tutor' => $mentorTutorName,
                 'date' => $this->convert($startDate, $endDate),
                 'time_spent' => $timeSpent,

--- a/app/Actions/Payment/UnpaidActivitiesAction.php
+++ b/app/Actions/Payment/UnpaidActivitiesAction.php
@@ -24,6 +24,7 @@ class UnpaidActivitiesAction
             $timeSpent = $data->end_date ? $startDate->diffInMinutes($endDate) : 0;
             $feeHours = $data->fee_hours;
             $cutoffStatus = $data->cutoff_status;
+            $students = implode(", ", $data->timesheet->ref_program->pluck('student_name')->toArray());
 
             return [
                 'id' => $activityId,
@@ -34,6 +35,7 @@ class UnpaidActivitiesAction
                     'type' => $package->type_of,
                     'category' => $package->category,
                 ],
+                'students' => $students,
                 'mentor_tutor' => $mentorTutorName,
                 'date' => $this->convert($startDate, $endDate),
                 'time_spent' => $timeSpent,

--- a/app/Http/Controllers/Api/V1/LogController.php
+++ b/app/Http/Controllers/Api/V1/LogController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class LogController extends Controller
+{
+    public function index(string $visited_page, ?string $detail)
+    {
+        $user = auth('sanctum')->check() ? auth('sanctum')->user()->full_name : "Anonymous";
+        $message = "{$user} has visited page {$visited_page}";
+        if ( $detail )
+            $message .= " use detail {$detail}"; 
+
+        Log::info($message);
+
+        return response()->json([
+            'message' => 'Log has been created.'
+        ], JsonResponse::HTTP_OK);
+    }
+}

--- a/app/Http/Requests/Activity/UpdateRequest.php
+++ b/app/Http/Requests/Activity/UpdateRequest.php
@@ -54,17 +54,17 @@ class UpdateRequest extends FormRequest
                 'required',
                 'date',
                 'date_format:Y-m-d H:i:s',
-                new ExistStartDateActivities('POST', $timesheet_id, $activity_id),
+                new ExistStartDateActivities('PUT', $timesheet_id, $activity_id),
                 new LimitedDurationActivity($timesheet_id, $dateParams)
             ],
             'end_date' => [
                 'nullable', 
                 'date', 
                 'date_format:Y-m-d H:i:s',
-                'after:start_date',
+                'after_or_equal:date',
                 new LimitedDurationActivity($timesheet_id, $dateParams),
             ],
-            'meeting_link' => 'required|active_url',
+            'meeting_link' => 'nullable|active_url',
             'status' => [
                 'nullable', 
                 'integer',

--- a/app/Observers/ActivityObserver.php
+++ b/app/Observers/ActivityObserver.php
@@ -43,6 +43,8 @@ class ActivityObserver implements ShouldHandleEventsAfterCommit
      */
     public function updated(Activity $activity): void
     {
+        $activityId = $activity->id;
+
         /**
          * Listening to 'updated cutoff_ref_id'
          */
@@ -54,7 +56,6 @@ class ActivityObserver implements ShouldHandleEventsAfterCommit
             # not yet meaning unpaid
             if ( $newValue_of_cutoffStatus == 'not yet' && $newValue_of_cutoffrefId == NULL ) #1
             {
-                $activityId = $activity->id;
                 Log::info($this->userName . ' has unassigned the activity no. ' . $activityId );
                 
             } 
@@ -66,9 +67,28 @@ class ActivityObserver implements ShouldHandleEventsAfterCommit
             return;
         }
 
-        $activityId = $activity->id;
-        $endTime = Carbon::parse($activity->end_date)->format('d M Y H:i');
-        Log::info($this->userName . ' just completed the activity no. ' . $activityId . ' at ' . $endTime);
+        /**
+         * Listening to 'updated end_date
+         */
+        if ( $activity->wasChanged('end_date') )
+        {
+            $endTime = $activity->end_date != NULL ? Carbon::parse($activity->end_date)->format('d M Y H:i') : 'NULL';
+            Log::info($this->userName . ' has just updated the end date to ' . $endTime . ' of activity no. ' . $activityId);
+        }
+
+        /**
+         * Listening to 'updated status'
+         */
+        if ( $activity->wasChanged('status') )
+        {
+            if ( $activity->status == 1 )
+                Log::info($this->userName . ' has just completed the activity no. ' . $activityId);
+            else
+                Log::info($this->userName . ' has just undone the completed activity no. ' . $activityId);
+        }
+
+        Log::info($this->userName . ' has just update the activity.');
+
     }
 
     /**

--- a/app/Services/Activity/ActivityDataService.php
+++ b/app/Services/Activity/ActivityDataService.php
@@ -24,12 +24,28 @@ class ActivityDataService
             $start_time = $start_date->format('H:i');
             $end_time = $end_date ? $end_date->format('H:i') : 0;
             $estimate = $end_date ? $start_date->diffInMinutes($end_date) : 0;
+            $is_disabled = $data->cutoff_history ? true : false;
 
-            return $data->toArray() + [
+            return [
+                'id' => $data->id,
+                'timesheet_id' => $data->timesheet_id,
+                'activity' => $data->activity,
+                'description' => $data->description,
+                'start_date' => $data->start_date,
+                'end_date' => $data->end_date,
+                'fee_horus' => $data->fee_hours,
+                'additional_fee' => $data->additional_fee,
+                'bonus_fee' => $data->bonus_fee,
+                'time_spent' => $data->time_spent,
+                'meeting_link' => $data->meeting_link,
+                'status' => $data->status,
+                'cutoff_status' => $data->cutoff_status,
+                'cutoff_ref_id' => $data->cutoff_ref_id,
                 'date' => $start_date->format('Y-m-d'),
                 'start_time' => $start_time,
                 'end_time' => $end_time,
                 'estimate' => $estimate,
+                'disabled_changes' => $is_disabled
             ];
         });
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\Api\V1\MentorTutor\ComponentController as V1MentorTutor
 use App\Http\Controllers\Api\V1\Programs\ListController as V1ProgramsListController;
 use App\Http\Controllers\Api\V1\TimesheetController as V1TimesheetController;
 use App\Http\Controllers\Api\V1\ActivityController as V1ActivitiesController;
+use App\Http\Controllers\Api\V1\LogController;
 use App\Http\Controllers\Api\V1\Packages\ListController as V1PackagesListController;
 use App\Http\Controllers\Api\V1\User\ListController as V1UserListController;
 use App\Http\Controllers\Api\V1\Payment\PaymentController as V1PaymentController;
@@ -173,3 +174,6 @@ Route::prefix('package')->group(function () {
 });
 
 Route::POST('identity/generate-token', [V1LoginController::class, 'authenticateNonAdmin']);
+
+/* log everytime user visit any pages */
+Route::middleware('auth:sanctum')->get('visit/{page_name}/{detail?}', [LogController::class, 'index']);


### PR DESCRIPTION
what's new?
1. updated activity log whenever user changes either status or end_date
2. fix bug related to problem occurs "It looks like the date you selected has already occurred. Please choose a different date. " when update the status.
3. added children name in list pre-cutoff and completed cutoff.
4. added extra info named "disabled_changes" within the list of activities. in order to prevent end-user update the activity attributes when the activity itself already been paid. or have been created as cutoff.
5. added 1 new endpoint, the suggestion from me is to put it in everytime end-user was visit any pages. Why? so we could track the journey of those users.
